### PR TITLE
Fix bad link (no protocol)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # arc-example-working-locally
 
-extends the tutorial from [https://arc.codes/guides/offline](arc.codes/guides/offline) with a JSON API that does classic CRUD
+extends the tutorial from <https://arc.codes/guides/offline> with a JSON API that does classic CRUD
 
 setup
 ```bash


### PR DESCRIPTION
Also use autolink syntax since text and link are the same. https://daringfireball.net/projects/markdown/syntax#autolink